### PR TITLE
Bug fix - vote page

### DIFF
--- a/views/vote.ejs
+++ b/views/vote.ejs
@@ -53,7 +53,6 @@
 </div>
 
 <script>
-  const currentLocation = $(location)[0].pathname;
   let idToDelete = undefined;
 
   const renderChart = (data) => {


### PR DESCRIPTION
### What does this PR do?
remove `currentLocation` from vote page for not being declared twice